### PR TITLE
ci: update actions to avoid warning

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,17 +12,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: SetUp Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.10"
           architecture: x64
 
       - name: Checkout Resource
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
 
       - name: Checkout Bot
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with: 
           repository: yuanyan3060/Arknights-Bot-Resource-Bot
           path: $GITHUB_WORKSPACE/../Arknights-Bot-Resource-Bot
@@ -48,7 +48,7 @@ jobs:
         shell: bash
 
       - name: Commit changes
-        uses: EndBug/add-and-commit@v7
+        uses: EndBug/add-and-commit@v9
         with:
           author_name: github-actions
           author_email: 41898282+github-actions[bot]@users.noreply.github.com
@@ -63,7 +63,7 @@ jobs:
           rm -rf ./Arknights-Bot-Resource-Bot
           python ./levels_gen.py
       - name: Commit changes
-        uses: EndBug/add-and-commit@v7
+        uses: EndBug/add-and-commit@v9
         with:
           author_name: yuanyan3060
           author_email: 1846865993@qq.com


### PR DESCRIPTION
通过更新相关 actions 的版本以避免现有的诸多警告信息，我检查了所有的 breaking changes，看起来没有问题。