### PR TITLE
feat: 地图数据生成脚本添加对生息演算模式地图的支持，添加生成与MAA适配的地图数据文件的Python脚本

### DIFF
--- a/levels_split_gen.py
+++ b/levels_split_gen.py
@@ -77,7 +77,9 @@ for i in Path("gamedata/levels/obt/crisis/v2").glob("*.json"):
     }
     levels.append(level)
 
-result = []
+if not Path("generated_level_data").exists():
+    Path("generated_level_data").mkdir()
+
 for level in levels:
     name = level["name"]
     code = level["code"]
@@ -119,11 +121,11 @@ for level in levels:
                     isEnd = True
                 tmp.append(
                     {
-                        "heightType": tile_data["heightType"],
                         "buildableType": tile_data["buildableType"],
-                        "tileKey":tile_data["tileKey"],
-                        "isStart": isStart,
-                        "isEnd":isEnd
+                        "heightType": tile_data["heightType"],
+                        "isEnd":not (isEnd and isStart) and isEnd,
+                        "isStart": not (isEnd and isStart) and isStart,
+                        "tileKey":tile_data["tileKey"]
                     }
                 )
             tiles.append(tmp)
@@ -133,19 +135,18 @@ for level in levels:
             view = maps[level_path]
         else:
             continue
-        result.append({
-            "name":name,
+        result = {
             "code": code,
-            "levelId": levelId,
-            "stageId":stageId,
-            "width": width,
             "height": height,
+            "levelId": levelId,
+            "name":name,
+            "stageId":stageId,
             "tiles": tiles,
-            "view": view
-        })
+            "view": view,
+            "width": width
+        }
+        with open("generated_level_data/" + stageId + "-" + levelId.replace("/", "-") + ".json", "w+", encoding="UTF-8") as fp:
+            json.dump(result, fp, indent=4, ensure_ascii=False)
     except Exception as e:
         print(e)
         pass
-
-with open("levels.json", "w", encoding="UTF-8") as fp:
-    json.dump(result, fp, indent=2, ensure_ascii=False)


### PR DESCRIPTION
请问对于地图左下角墙壁格的`isStart` 和 `isEnd`的处理这样可以吗？
```Python
"isEnd":   not (isEnd and isStart) and isEnd,
"isStart": not (isEnd and isStart) and isStart,
```
